### PR TITLE
Fixing for newdesign

### DIFF
--- a/lib/pixiv/member.rb
+++ b/lib/pixiv/member.rb
@@ -13,7 +13,8 @@ module Pixiv
     # @return [String]
     lazy_attr_reader(:name) { at!('.profile-unit h1').inner_text }
     # @return [Integer]
-    lazy_attr_reader(:member_id) { at!('input[name="user_id"]')['value'].to_i }
+    #lazy_attr_reader(:member_id) { at!('input[name="user_id"]')['value'].to_i }
+    lazy_attr_reader(:member_id) { at!('link[hreflang=en]')['href'][%r{/users/(\d+)}, 1].to_i }
     # @return [Integer]
     lazy_attr_reader(:pixiv_id) { profile_image_url[%r{/profile/([a-z_-]+)/}, 1] }
     # @return [String]

--- a/spec/fixtures/member_6.html
+++ b/spec/fixtures/member_6.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <link rel="alternate" hreflang="en" href="http://www.pixiv.com/users/123456" />
+  <link rel="alternate" hreflang="en" href="http://www.pixiv.com/users/6" />
   <title>Member #6</title>
 </head>
 <body>


### PR DESCRIPTION
PixivのmemberページのHTML構造が変わっていて、Memberクラスの一部のattributeを取得しようとするとエラーが出ていました。
それに対応する修正を施しましたので、よろしければ取り込んでいただけたらと思います。
