### PR TITLE
add mypixiv_only? method

### DIFF
--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -57,6 +57,9 @@ module Pixiv
     # @return [Integer]
     lazy_attr_reader(:score) { at!('.score-count').inner_text.to_i }
 
+    # @return [Boolean]
+    lazy_attr_reader(:mypixiv_only?) { doc.at('[@class="_no-item closed"]').nil?.! }
+
     alias id illust_id
     alias author_id member_id
     alias author_name member_name

--- a/spec/fixtures/mypixiv_only.html
+++ b/spec/fixtures/mypixiv_only.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Mypixiv only</title>
+</head>
+<body>
+<section class="restricted-content">
+    <div class="_no-item closed">
+        <p>この作品は、<a href="/member.php?id=42">テスト</a>さんのマイピクにのみ公開されています。</p>
+        <p>閲覧したい場合は<a href="/mypixiv_add.php?id=42">マイピク申請</a>を行い、<a href="/member.php?id=42">テスト</a>さんとマイピクになりましょう</p>
+    </div>
+</section>
+</body>
+</html>

--- a/spec/pixiv/illust_spec.rb
+++ b/spec/pixiv/illust_spec.rb
@@ -17,6 +17,7 @@ describe Pixiv::Illust do
     its(:small_image_url) { should == 'http://i1.pixiv.net/img1/img/sayoko/345_s.jpg' }
     its(:medium_image_url) { should == 'http://i1.pixiv.net/img1/img/sayoko/345_m.jpg' }
     its(:original_image_url) { should == 'http://i1.pixiv.net/img1/img/sayoko/345.jpg' }
+    its(:mypixiv_only?) { should == false }
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }
@@ -51,6 +52,7 @@ describe Pixiv::Illust do
     its(:small_image_url) { should == 'http://i1.pixiv.net/img1/img/duke/105_s.jpg' }
     its(:medium_image_url) { should == 'http://i1.pixiv.net/img1/img/duke/105_m.jpg' }
     its(:original_image_url) { should == 'http://i1.pixiv.net/img1/img/duke/105.jpg' }
+    its(:mypixiv_only?) { should == false }
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }
@@ -61,5 +63,12 @@ describe Pixiv::Illust do
       expect(Pixiv::Illust.url(345)).
         to eq('http://www.pixiv.net/member_illust.php?mode=medium&illust_id=345')
     end
+  end
+
+  describe 'mypixiv_only?' do
+    let(:illust_doc) { fixture_as_doc('mypixiv_only.html') }
+
+    subject { Pixiv::Illust.new(illust_doc) }
+    its(:mypixiv_only?) { should == true }
   end
 end

--- a/spec/pixiv/illust_spec.rb
+++ b/spec/pixiv/illust_spec.rb
@@ -37,6 +37,7 @@ describe Pixiv::Illust do
         score: 130,
         small_image_url: 'http://i1.pixiv.net/img1/img/duke/105_s.jpg',
         medium_image_url: 'http://i1.pixiv.net/img1/img/duke/105_m.jpg',
+        mypixiv_only?: true,
       }
     end
     subject { Pixiv::Illust.new(illust_doc, @attrs) }
@@ -52,7 +53,7 @@ describe Pixiv::Illust do
     its(:small_image_url) { should == 'http://i1.pixiv.net/img1/img/duke/105_s.jpg' }
     its(:medium_image_url) { should == 'http://i1.pixiv.net/img1/img/duke/105_m.jpg' }
     its(:original_image_url) { should == 'http://i1.pixiv.net/img1/img/duke/105.jpg' }
-    its(:mypixiv_only?) { should == false }
+    its(:mypixiv_only?) { should == true }
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }


### PR DESCRIPTION
When mypixiv only illust, many method raise error.
(for example, illust.title raise Pixiv::Error::NodeNotFound in page.rb:107)

So we need the method which check a illust is mypixiv only or not.
