### PR TITLE
Fix caption method when not caption writed.

### DIFF
--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -46,7 +46,15 @@ module Pixiv
     # @return [Array<String>]
     lazy_attr_reader(:tag_names) { search!('ul.tags a.text').map {|n| n.inner_text } }
     # @return [String]
-    lazy_attr_reader(:caption) { at!('.work-info .caption').inner_text }
+    lazy_attr_reader(:caption) {
+      node = doc.at('.work-info .caption')
+      if node
+        node.inner_text
+      else
+        ""
+      end
+    }
+
     # @api experimental
     # @return [Array<Nokogiri::XML::NodeSet, nil>]
     lazy_attr_reader(:anchors_in_caption) { doc.search('.work-info .caption a') }

--- a/spec/pixiv/illust_spec.rb
+++ b/spec/pixiv/illust_spec.rb
@@ -62,4 +62,11 @@ describe Pixiv::Illust do
         to eq('http://www.pixiv.net/member_illust.php?mode=medium&illust_id=345')
     end
   end
+
+  describe 'no caption user' do
+    let(:illust_doc) { fixture_as_doc('empty.html') }
+
+    subject { Pixiv::Illust.new(illust_doc) }
+    its(:caption) { should == "" }
+  end
 end


### PR DESCRIPTION
If the user don't write a caption, the caption method will rise error.
But Pixiv allow no caption illust, so it's not error.

This PR fix the method won't rise error when there is no body.
