### PR TITLE
add delete? method

### DIFF
--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -83,7 +83,7 @@ module Pixiv
     def manga?; !!num_pages end
 
     # @return [Boolean]
-    lazy_attr_reader(:delete?) { is_delete? }
+    lazy_attr_reader(:deleted?) { is_deleted? }
 
     private
 
@@ -99,7 +99,7 @@ module Pixiv
       @image_url_components ||= medium_image_url.match(%r{^(.+)_m(\.\w+(?:\?\d+)?)$}).to_a[1, 3]
     end
 
-    def is_delete?
+    def is_deleted?
       nodes = doc.search("._unit span")
       return false unless nodes
       nodes.each do |node|

--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -82,6 +82,9 @@ module Pixiv
     # @return [Boolean]
     def manga?; !!num_pages end
 
+    # @return [Boolean]
+    lazy_attr_reader(:delete?) { is_delete? }
+
     private
 
     def get_upload_at
@@ -94,6 +97,15 @@ module Pixiv
 
     def image_url_components
       @image_url_components ||= medium_image_url.match(%r{^(.+)_m(\.\w+(?:\?\d+)?)$}).to_a[1, 3]
+    end
+
+    def is_delete?
+      nodes = doc.search("._unit span")
+      return false unless nodes
+      nodes.each do |node|
+        return true if node.inner_text.include? "この作品は削除されました。"
+      end
+      false
     end
   end
 

--- a/spec/fixtures/delete.html
+++ b/spec/fixtures/delete.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title></title>
+</head>
+<body>
+<div class="layout-body">
+  <div class="_unit">
+    <div style="text-align:center;padding:2em;">
+      <span style="font-weight:bold;font-size:large;">この作品は削除されました。</span>
+    </div>
+  </div>
+</div>
+</body>
+</html>
+

--- a/spec/pixiv/illust_spec.rb
+++ b/spec/pixiv/illust_spec.rb
@@ -22,6 +22,7 @@ describe Pixiv::Illust do
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }
+    its(:delete?) { should == false }
   end
 
   describe '.new', 'given attrs covers attrs extracted from doc' do
@@ -40,6 +41,7 @@ describe Pixiv::Illust do
         small_image_url: 'http://i1.pixiv.net/img1/img/duke/105_s.jpg',
         medium_image_url: 'http://i1.pixiv.net/img1/img/duke/105_m.jpg',
         mypixiv_only?: true,
+        delete?: true,
       }
     end
     subject { Pixiv::Illust.new(illust_doc, @attrs) }
@@ -60,8 +62,16 @@ describe Pixiv::Illust do
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }
+    its(:delete?) { should == true }
   end
 
+  describe 'delete illust page' do
+    let(:illust_doc) { fixture_as_doc('delete.html') }
+
+    subject { Pixiv::Illust.new(illust_doc) }
+    its(:delete?) { should == true }
+  end
+  
   describe '.url' do
     it 'returns url for illust id' do
       expect(Pixiv::Illust.url(345)).

--- a/spec/pixiv/illust_spec.rb
+++ b/spec/pixiv/illust_spec.rb
@@ -22,7 +22,7 @@ describe Pixiv::Illust do
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }
-    its(:delete?) { should == false }
+    its(:deleted?) { should == false }
   end
 
   describe '.new', 'given attrs covers attrs extracted from doc' do
@@ -41,7 +41,7 @@ describe Pixiv::Illust do
         small_image_url: 'http://i1.pixiv.net/img1/img/duke/105_s.jpg',
         medium_image_url: 'http://i1.pixiv.net/img1/img/duke/105_m.jpg',
         mypixiv_only?: true,
-        delete?: true,
+        deleted?: true,
       }
     end
     subject { Pixiv::Illust.new(illust_doc, @attrs) }
@@ -62,14 +62,14 @@ describe Pixiv::Illust do
     its(:num_pages) { should == nil }
     its(:illust?) { should == true }
     its(:manga?) { should == false }
-    its(:delete?) { should == true }
+    its(:deleted?) { should == true }
   end
 
   describe 'delete illust page' do
     let(:illust_doc) { fixture_as_doc('delete.html') }
 
     subject { Pixiv::Illust.new(illust_doc) }
-    its(:delete?) { should == true }
+    its(:deleted?) { should == true }
   end
   
   describe '.url' do


### PR DESCRIPTION
Pixiv return 404 status code in deleted illust page.
But, few deleted illust page, not return 404.
If we call title method for these illust, rise error.

So we need delete? method, which return true in deleted illust page which not return 404.
These page don't have distinguishable node, so we need check page by deleted message...