### PR TITLE
Fix a bug where login fails

### DIFF
--- a/lib/pixiv/client.rb
+++ b/lib/pixiv/client.rb
@@ -224,7 +224,7 @@ module Pixiv
     end
 
     def member_id_from_mypage(doc)
-      doc.at('a.user-link')['href'][/\d+$/].to_i
+      doc.at('a.user-name')['href'][/\d+$/].to_i
     end
   end
 


### PR DESCRIPTION
# Summary
Fixed a bug where login fails.
Now, `a.user-link` attribute is not found. So I replaced it with `a.user-name`.

# Problem Summary
This is an error log on the master.

## Source code
```ruby
require 'pixiv'

pixiv = Pixiv.client('id', 'password') do |agent|
  agent.user_agent_alias = 'Mac Safari'
end


MEMBER_ID = 52141
member = pixiv.member(MEMBER_ID)
puts member.works.first
```

## An error log
On the master branch.
```
ruby foo.rb                                                                                                                                                               [2.3.3 (global)]
/home/sachin21dev/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/pixiv-0.0.9/lib/pixiv/client.rb:57: warning: circular argument reference - member_id
/home/sachin21dev/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/pixiv-0.0.9/lib/pixiv/client.rb:227:in `member_id_from_mypage': undefined method `[]' for nil:NilClass (NoMethodError)
        from /home/sachin21dev/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/pixiv-0.0.9/lib/pixiv/client.rb:52:in `login'
        from /home/sachin21dev/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/pixiv-0.0.9/lib/pixiv/client.rb:36:in `initialize'
        from /home/sachin21dev/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/pixiv-0.0.9/lib/pixiv.rb:29:in `new'
        from /home/sachin21dev/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/pixiv-0.0.9/lib/pixiv.rb:29:in `client'
        from hoge.rb:4:in `<main>'
```

Thanks.
