### PR TITLE
Fix member id extraction and work with bookmarks

### DIFF
--- a/lib/pixiv/bookmark_list.rb
+++ b/lib/pixiv/bookmark_list.rb
@@ -23,7 +23,7 @@ module Pixiv
     # @param [Nokogiri::XML::Node] node
     # @return [Hash{Symbol=>Object}] illust_hash
     def hash_from_list_item(node)
-      return nil if node.at('img[src*="limit_unknown_s.png"]')
+      return nil if node.at('img[data-src*="limit_unknown_s.png"]')
       member_node = node.at('a[href^="member_illust.php?id="]')
       illust_node = node.at('a')
       illust_id = illust_node['href'][/illust_id=(\d+)/, 1].to_i

--- a/lib/pixiv/bookmark_list.rb
+++ b/lib/pixiv/bookmark_list.rb
@@ -25,7 +25,7 @@ module Pixiv
     def hash_from_list_item(node)
       return nil if node.at('img[data-src*="limit_unknown_s.png"]')
       return nil if node.at('img[data-src*="limit_mypixiv_s.png"]')
-      member_node = node.at('a[href^="member_illust.php?id="]')
+      member_node = node.at('a[href^="/member.php?id="]')
       illust_node = node.at('a')
       illust_id = illust_node['href'][/illust_id=(\d+)/, 1].to_i
       {

--- a/lib/pixiv/bookmark_list.rb
+++ b/lib/pixiv/bookmark_list.rb
@@ -24,6 +24,7 @@ module Pixiv
     # @return [Hash{Symbol=>Object}] illust_hash
     def hash_from_list_item(node)
       return nil if node.at('img[data-src*="limit_unknown_s.png"]')
+      return nil if node.at('img[data-src*="limit_mypixiv_s.png"]')
       member_node = node.at('a[href^="member_illust.php?id="]')
       illust_node = node.at('a')
       illust_id = illust_node['href'][/illust_id=(\d+)/, 1].to_i

--- a/lib/pixiv/bookmark_list.rb
+++ b/lib/pixiv/bookmark_list.rb
@@ -12,7 +12,7 @@ module Pixiv
     }
     # @return [Array<Hash{Symbol=>Object}, nil>]
     lazy_attr_reader(:page_hashes) {
-      search!('li[id^="li_"]').map {|n| hash_from_list_item(n) }
+      search!('li.image-item').map {|n| hash_from_list_item(n) }
     }
 
     # @deprecated Use {#total_count} instead.

--- a/lib/pixiv/client.rb
+++ b/lib/pixiv/client.rb
@@ -42,7 +42,10 @@ module Pixiv
     # @param [String] password
     def login(pixiv_id, password)
       doc = agent.get("https://accounts.pixiv.net/login?lang=ja&source=pc&view_type=page")
-      return if doc && doc.body =~ /logout/
+      if doc && doc.body =~ /logout/
+        @member_id = member_id_from_mypage(doc)
+        return
+      end
       form = doc.forms_with(action: '/login').first
       puts doc.body and raise Error::LoginFailed, 'login form is not available' unless form
       form.pixiv_id = pixiv_id

--- a/lib/pixiv/client.rb
+++ b/lib/pixiv/client.rb
@@ -54,9 +54,9 @@ module Pixiv
 
     # @param [Integer] member_id
     # @return [Pixiv::Member] member bound to +self+
-    def member(member_id = member_id)
-      attrs = {member_id: member_id}
-      member = Member.lazy_new(attrs) { agent.get(Member.url(member_id)) }
+    def member(mid = member_id)
+      attrs = {member_id: mid}
+      member = Member.lazy_new(attrs) { agent.get(Member.url(mid)) }
       member.bind(self)
     end
 

--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -96,7 +96,11 @@ module Pixiv
     end
 
     def image_url_components
-      @image_url_components ||= medium_image_url.match(%r{^([^/]+//[^/]+/).+img/(.+p)0_m[^.]+(\.\w+(?:\?\d+)?)$}).to_a[1, 3]
+      if manga?
+        @image_url_components ||= medium_image_url.match(%r{^([^/]+//[^/]+/).+img/(.+p)0_m[^.]+(\.\w+(?:\?\d+)?)$}).to_a[1, 3]
+      else
+        @image_url_components ||= at!(".original-image").attributes['data-src'].text.match(%r{^([^/]+//[^/]+/).+img/(.+p)0(\.\w+(?:\?\d+)?)$}).to_a[1, 3]
+      end
     end
 
     def is_deleted?

--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -21,7 +21,7 @@ module Pixiv
     # @return [Array<String>]
     lazy_attr_reader(:original_image_urls) {
       illust? ? [original_image_url]
-              : (0...num_pages).map {|n| image_url_components.join("_p#{n}") }
+              : (0...num_pages).map {|n| image_url_components[0] + 'img-original/img/' + image_url_components[1] + n.to_s + image_url_components[2] }
     }
     # @return [String]
     lazy_attr_reader(:original_image_referer) { ROOT_URL + '/' + at!('//div[@class="works_display"]/a')['href'] }

--- a/lib/pixiv/illust.rb
+++ b/lib/pixiv/illust.rb
@@ -78,9 +78,11 @@ module Pixiv
     # @return [String]
     def url; self.class.url(illust_id) end
     # @return [Boolean]
-    def illust?; !manga? end
+    def illust?; !(manga? or gif?) end
     # @return [Boolean]
     def manga?; !!num_pages end
+    # @return [Boolean]
+    def gif?; doc.at('[@class="_ugoku-illust-player-container"]').nil?.! end
 
     # @return [Boolean]
     lazy_attr_reader(:deleted?) { is_deleted? }

--- a/lib/pixiv/owned_illust_list.rb
+++ b/lib/pixiv/owned_illust_list.rb
@@ -30,7 +30,7 @@ module Pixiv
     }
     # @return [Integer]
     lazy_attr_reader(:member_id) {
-      doc.body[/pixiv\.context\.userId = '(\d+)'/, 1].to_i
+      doc.body[/pixiv\.context\.userId = (['"])(\d+)\1/, 2].to_i
     }
 
     # @return [String]

--- a/lib/pixiv/work_list.rb
+++ b/lib/pixiv/work_list.rb
@@ -28,7 +28,7 @@ module Pixiv
     # @param [Nokogiri::XML::Node] node
     # @return [Hash{Symbol=>Object}] illust_hash
     def hash_from_list_item(node)
-      return nil if node.at('img[src*="limit_unknown_s.png"]')
+      return nil if node.at('img[data-src*="limit_unknown_s.png"]')
       illust_node = node.at('a')
       illust_id = illust_node['href'][/illust_id=(\d+)/, 1].to_i
       hash = {

--- a/lib/pixiv/work_list.rb
+++ b/lib/pixiv/work_list.rb
@@ -29,6 +29,7 @@ module Pixiv
     # @return [Hash{Symbol=>Object}] illust_hash
     def hash_from_list_item(node)
       return nil if node.at('img[data-src*="limit_unknown_s.png"]')
+      return nil if node.at('img[data-src*="limit_mypixiv_s.png"]')
       illust_node = node.at('a')
       illust_id = illust_node['href'][/illust_id=(\d+)/, 1].to_i
       hash = {


### PR DESCRIPTION
Fixes for:
 - circular reference warning (parameter member_id has the same name as accessor member_id)
 - fix already logged in session member_id detection
 - ignore 'my pixiv only' works in lists
 - some more fixes to bookmark list parsing